### PR TITLE
libcxx: initializer_list: remove constexpr from size method

### DIFF
--- a/src/libcxx/initializer_list.cppm
+++ b/src/libcxx/initializer_list.cppm
@@ -14,7 +14,7 @@ template <typename T>
 class initializer_list {
  public:
     inline constexpr initializer_list() noexcept : b(nullptr), s(0) {}
-    inline constexpr size_t size() const noexcept { return s; }
+    inline size_t size() const noexcept { return s; }
     inline constexpr const T* begin() const noexcept { return b; }
     inline constexpr const T* end() const noexcept { return b + s; }
 


### PR DESCRIPTION
clang-10 panics when parsing code that use initializer_list vector
constructor, clang-11 is ok though. However, current github check
 compiles using clang-10

Signed-off-by: Fernando Lugo <lugo.fernando@gmail.com>