### PR TITLE
scripts: moddep: improve regex for import

### DIFF
--- a/scripts/moddeps.py
+++ b/scripts/moddeps.py
@@ -25,9 +25,9 @@ def create_dep(file_name, args):
         m = re.search(r'^export\s*module\s*(\S*);', line)
         if m is not None:
             dep.mod_name = m.group(1)
-        m = re.search(r'import\s*(\S*);', line)
+        m = re.search(r'^(export )?import\s*(\S*);', line)
         if m is not None:
-            dep.mod_deps.append(m.group(1))
+            dep.mod_deps.append(m.group(2))
 
     return dep
 


### PR DESCRIPTION
Make sure "import" or "export import" is the first part. This will avoid
that comments can be treat as imports by moddep.py script

Signed-off-by: Fernando Lugo <fernando@gmail.com>