### PR TITLE
dev: uart: pl011: update UART_LCR_H after baudrate

### DIFF
--- a/src/device/uart/pl011.cppm
+++ b/src/device/uart/pl011.cppm
@@ -73,11 +73,11 @@ enum UART_CR_bits : uint32_t {
 namespace device {
 
 void pl011::init() {
-    // enable fifo
-    reg(UART_LCR_H) = UART_LCR_H_FEN | UART_LCR_H_WLEN8;
-
     // set baudrate
     baudrate(baud);
+
+    // enable fifo
+    reg(UART_LCR_H) = UART_LCR_H_FEN | UART_LCR_H_WLEN8;
 
     // enable uart
     reg(UART_CR) = UART_CR_UARTEN | UART_CR_TXE | UART_CR_RXE;


### PR DESCRIPTION
From PL011 datasheet:
The UARTLCR_H, UARTIBRD, and UARTFBRD registers form the single 30-bit
wide UARTLCR Register that is updated on a single write strobe
generated by a UARTLCR_H write.

Signed-off-by: Fernando Lugo <lugo.fernando@gmail.com>