### PR TITLE
aarch64: enable MMU

### DIFF
--- a/src/board/qemu/aarch64/rules.mk
+++ b/src/board/qemu/aarch64/rules.mk
@@ -6,4 +6,4 @@
 .PHONY: qemu
 
 qemu: $(BUILD_DIR)/sc.bin
-	$(Q)qemu-system-aarch64 -M virt,secure=on,virtualization=on -cpu cortex-a53 -m 512 -smp 2 -nographic -semihosting -s -kernel $<
+	$(Q)qemu-system-aarch64 -M virt,secure=on,virtualization=on -cpu max -m 3072 -smp 2 -nographic -semihosting -s -kernel $<

--- a/src/core/cpu/armv8/cpu.cppm
+++ b/src/core/cpu/armv8/cpu.cppm
@@ -6,7 +6,9 @@
 
 module;
 
+#include <arch/aarch64/sysreg.h>
 #include <errcodes.h>
+#include <stdint.h>
 
 #include "exception_vector.h"
 
@@ -23,6 +25,16 @@ export using cpu_irq_handler = void(*)(int vec, void* data);
 
 namespace core::cpu {
 
+// 1:1 mmu mapping of the first 4GB
+static uint64_t xlate_table[4096 / 8] __attribute__((aligned(4096))) = {
+    // clang-format off
+    [0] = 0x00000421, // 1GB device memory
+    [1] = 0x4000070d, // 1GB writeback memory
+    [2] = 0x8000070d, // 1GB writeback memory
+    [3] = 0xc000070d, // 1GB writeback memory
+    // clang-format off
+};
+
 static cpu_irq_handler cpu_handler;
 static void* cpu_handler_data;
 
@@ -34,11 +46,28 @@ static int cpu_exception_handler(armv8::exception::regs*) {
     return 0;
 }
 
+static void mmu_init() {
+    sysreg_write(tcr_el1, 0x0000'3520UL);
+    sysreg_write(mair_el1, 0xff44'0400UL);
+
+    sysreg_write(ttbr0_el1, xlate_table);
+
+    unsigned long val = sysreg_read(sctlr_el1);
+    // enable mmu and D/I caches
+    val |= (1 << 12) | (1 << 2) | 1;
+    sysreg_write(sctlr_el1, val);
+
+    asm volatile("dsb sy");
+    asm volatile("isb");
+}
+
 }  // namespace core::cpu
 
 export namespace core::cpu {
 
-void early_init() {}
+void early_init() {
+    mmu_init();
+}
 
 void init() {
     armv8::exception::init();

--- a/src/core/cpu/armv8/start.S
+++ b/src/core/cpu/armv8/start.S
@@ -35,9 +35,6 @@ _start:
         msr     elr_el3, x0
 
 2:
-        // initialize sctlr_el1 reg before entering EL1
-        msr     sctlr_el1, xzr
-
         // configure EL2 registers
         mrs     x0, hcr_el2
         orr     x0, x0, HCR_EL2_RW


### PR DESCRIPTION
Add simple 1:1 mapping of the first 4G and enable MMU and cache

Signed-off-by: Fernando Lugo <lugo.fernando@gmail.com>